### PR TITLE
Update to leaf.bash to checkout monero v0.11.1.0

### DIFF
--- a/deployment/leaf.bash
+++ b/deployment/leaf.bash
@@ -22,7 +22,7 @@ sudo systemctl enable ntp
 cd /usr/local/src
 sudo git clone https://github.com/monero-project/monero.git
 cd monero
-sudo git checkout v0.11.0.0
+sudo git checkout v0.11.1.0
 curl https://raw.githubusercontent.com/Snipa22/nodejs-pool/master/deployment/monero_daemon.patch | sudo git apply -v
 sudo make -j$(nproc)
 sudo cp ~/nodejs-pool/deployment/monero.service /lib/systemd/system/


### PR DESCRIPTION
Very minor update to leaf.bash so it will checkout v0.11.1.0 from monero-project/monero rather than the older v.0.11.0.0.  Ran leaf.bash on a fresh install of Ubuntu 16.04.3 and it appears the patch was applied properly and monerod compiled.  The monerod is running and behaving as expected.